### PR TITLE
feat: Clean up enrollment ID; Rename to Assignment

### DIFF
--- a/android/src/main/java/com/amplitude/skylab/DefaultSkylabClient.java
+++ b/android/src/main/java/com/amplitude/skylab/DefaultSkylabClient.java
@@ -96,7 +96,6 @@ public class DefaultSkylabClient implements SkylabClient {
      */
     @Override
     public Future<SkylabClient> start(SkylabUser skylabUser) {
-        loadFromStorage();
         this.skylabUser = skylabUser;
         return executorService.submit(fetchAllCallable);
     }
@@ -117,10 +116,6 @@ public class DefaultSkylabClient implements SkylabClient {
         }
     }
 
-    // TODO: remove function
-    public String loadFromStorage() {
-        return null;
-    }
 
     private static String uuidToBase36(UUID uuid) {
         ByteBuffer bb = ByteBuffer.wrap(new byte[16]);

--- a/android/src/main/java/com/amplitude/skylab/DefaultSkylabClient.java
+++ b/android/src/main/java/com/amplitude/skylab/DefaultSkylabClient.java
@@ -1,8 +1,6 @@
 package com.amplitude.skylab;
 
 import android.app.Application;
-import android.content.Context;
-import android.content.SharedPreferences;
 import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Log;
@@ -47,7 +45,6 @@ public class DefaultSkylabClient implements SkylabClient {
     String instanceName;
     Application application;
     String apiKey;
-    String enrollmentId;
     SkylabConfig config;
     HttpUrl serverUrl;
 
@@ -120,22 +117,9 @@ public class DefaultSkylabClient implements SkylabClient {
         }
     }
 
+    // TODO: remove function
     public String loadFromStorage() {
-        // Use a common SharedPreferences across all instances for the enrollment ID
-        SharedPreferences sharedPreferences =
-                application.getSharedPreferences(SkylabConfig.SHARED_PREFS_SHARED_NAME,
-                        Context.MODE_PRIVATE);
-        enrollmentId = sharedPreferences.getString(SkylabConfig.ENROLLMENT_ID_KEY, null);
-        if (enrollmentId == null) {
-            Log.i(Skylab.TAG, "Creating new id for enrollment");
-            enrollmentId = generateEnrollmentId();
-            sharedPreferences.edit().putString(SkylabConfig.ENROLLMENT_ID_KEY, enrollmentId).apply();
-        }
-        return enrollmentId;
-    }
-
-    private static String generateEnrollmentId() {
-        return uuidToBase36(UUID.randomUUID());
+        return null;
     }
 
     private static String uuidToBase36(UUID uuid) {

--- a/android/src/main/java/com/amplitude/skylab/SharedPrefsStorage.java
+++ b/android/src/main/java/com/amplitude/skylab/SharedPrefsStorage.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Simple SharedPrefs backed storage for caching values locally.
+ * Simple SharedPrefs backed storage for caching assigned variant values locally.
  *
  * This is not multi-process safe.
  */

--- a/android/src/main/java/com/amplitude/skylab/SharedPrefsStorage.java
+++ b/android/src/main/java/com/amplitude/skylab/SharedPrefsStorage.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Simple SharedPrefs backed storage for caching enrollment values locally.
+ * Simple SharedPrefs backed storage for caching values locally.
  *
  * This is not multi-process safe.
  */

--- a/android/src/main/java/com/amplitude/skylab/SkylabClient.java
+++ b/android/src/main/java/com/amplitude/skylab/SkylabClient.java
@@ -84,7 +84,7 @@ public interface SkylabClient {
     SkylabClient setContextProvider(ContextProvider provider);
 
     /**
-     * Sets a listener for enrollment events. See {@link SkylabListener}
+     * Sets a listener for variant change events. See {@link SkylabListener}
      */
     SkylabClient setListener(SkylabListener skylabListener);
 

--- a/android/src/main/java/com/amplitude/skylab/SkylabClient.java
+++ b/android/src/main/java/com/amplitude/skylab/SkylabClient.java
@@ -84,7 +84,7 @@ public interface SkylabClient {
     SkylabClient setContextProvider(ContextProvider provider);
 
     /**
-     * Sets a listener for variant change events. See {@link SkylabListener}
+     * Sets a listener for assigned variant change events. See {@link SkylabListener}
      */
     SkylabClient setListener(SkylabListener skylabListener);
 

--- a/android/src/main/java/com/amplitude/skylab/SkylabConfig.java
+++ b/android/src/main/java/com/amplitude/skylab/SkylabConfig.java
@@ -17,7 +17,6 @@ public class SkylabConfig {
     static final String SHARED_PREFS_SHARED_NAME = "amplitude-flags-shared";
 
     static final String SHARED_PREFS_STORAGE_NAME = "amplitude-flags-saved";
-    static final String ENROLLMENT_ID_KEY = "enrollmentId";
 
     /**
      * Defaults for {@link SkylabConfig}

--- a/android/src/main/java/com/amplitude/skylab/SkylabListener.java
+++ b/android/src/main/java/com/amplitude/skylab/SkylabListener.java
@@ -3,7 +3,7 @@ package com.amplitude.skylab;
 import java.util.Map;
 
 /**
- * Classes can implement this interface to handle changes in variants for a user.
+ * Classes can implement this interface to handle changes in assigned variants for a user.
  * The {@link #onVariantsChanged(SkylabUser, Map)} method is called when a
  * {@link SkylabClient} fetches variant values that are different from previously fetched
  * values.

--- a/android/src/main/java/com/amplitude/skylab/SkylabListener.java
+++ b/android/src/main/java/com/amplitude/skylab/SkylabListener.java
@@ -3,7 +3,7 @@ package com.amplitude.skylab;
 import java.util.Map;
 
 /**
- * Classes can implement this interface to handle changes in enrollment.
+ * Classes can implement this interface to handle changes in variants for a user.
  * The {@link #onVariantsChanged(SkylabUser, Map)} method is called when a
  * {@link SkylabClient} fetches variant values that are different from previously fetched
  * values.


### PR DESCRIPTION
Remove the enrollment ID from the code base since it is no longer being used. 

Talked with curtis about "enrollment" and that we would like to call it "assignment" instead. 